### PR TITLE
Fixed redefined error for `FE_*`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,34 @@
+use std::collections::HashSet;
+
 extern crate bindgen;
 extern crate pkg_config;
+
+#[derive(Debug)]
+struct IgnoreMacros(HashSet<String>);
+
+impl bindgen::callbacks::ParseCallbacks for IgnoreMacros {
+    fn will_parse_macro(&self, name: &str) -> bindgen::callbacks::MacroParsingBehavior {
+        if self.0.contains(name) {
+            bindgen::callbacks::MacroParsingBehavior::Ignore
+        } else {
+            bindgen::callbacks::MacroParsingBehavior::Default
+        }
+    }
+}
+
+fn get_ignored_macros() -> IgnoreMacros {
+    let mut ignored = HashSet::new();
+    ignored.insert("FE_INVALID".to_string());
+    ignored.insert("FE_DIVBYZERO".to_string());
+    ignored.insert("FE_OVERFLOW".to_string());
+    ignored.insert("FE_UNDERFLOW".to_string());
+    ignored.insert("FE_INEXACT".to_string());
+    ignored.insert("FE_TONEAREST".to_string());
+    ignored.insert("FE_DOWNWARD".to_string());
+    ignored.insert("FE_UPWARD".to_string());
+    ignored.insert("FE_TOWARDZERO".to_string());
+    IgnoreMacros(ignored)
+}
 
 fn main() {
     let _ = pkg_config::probe_library("libobs").unwrap();
@@ -7,6 +36,8 @@ fn main() {
     let bindings = bindgen::builder()
         .header("wrapper.h")
         .blacklist_type("_bindgen_ty_2")
+        // This is a workaround for a redefine error from bindgen.
+        .parse_callbacks(Box::new(get_ignored_macros()))
         .generate()
         .expect("Unable to generate libOBS bindings. Do you have OBS >= 23.0.0 installed?");
 


### PR DESCRIPTION
This commit fixes buildgen errors stating that there were duplicate definitions for:
- `FE_INVALID`
- `FE_DIVBYZERO`
- `FE_OVERFLOW`
- `FE_UNDERFLOW`
- `FE_INEXACT`
- `FE_TONEAREST`
- `FE_DOWNWARD`
- `FE_UPWARD`
- `FE_TOWARDZERO`

It ignores these macros, but I do not know the details of how bindgen works, so please let me know if you think this will raise any other problems.

Tested with OBS 27.2.4 on WSL2 Fedora

See [this comment](https://github.com/rust-lang/rust-bindgen/issues/687#issuecomment-450750547).